### PR TITLE
Make it known to use Set() syntax for 3.8+.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -39,7 +39,7 @@ You can do this by adding the following line to your RT::SiteConfig:
 
 @MailPlugins = qw(Auth::MailFrom Filter::TakeAction);
 
-If you are running RT-3.8 you will need to use slightly different syntax
+If you are running RT-3.8 and above you will need to use slightly different syntax
 
 Set(@MailPlugins, qw(Auth::MailFrom Filter::TakeAction));
 


### PR DESCRIPTION
New users may be confused and use the old syntax because now it appears that you should only use Set() syntax for specifically version 3.8.
