### PR TITLE
Support for parsing commands from a header.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -52,5 +52,10 @@ There is an optional configuration option CommandByMailGroup
 Set($CommandByMailGroup, group_id);
 You can find the id by browsing to Configuration -> Groups
 
+You can get it to look for commands in headers as well by  setting
+CommandByMailHeader like:
+
+    Set($CommandByMailHeader, "X-RT-Command");
+
 Enjoy.
 

--- a/README
+++ b/README
@@ -10,8 +10,8 @@ This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself.
 
 DESCRIPTION
-    This extension parse content of incoming messages for list commands.
-    Format of commands is:
+    This extension parses the body and headers of incoming messages
+    for list commands. Format of commands is:
 
         Command: value
         Command: value

--- a/lib/RT/Interface/Email/Filter/TakeAction.pm
+++ b/lib/RT/Interface/Email/Filter/TakeAction.pm
@@ -18,8 +18,8 @@ RT::Interface::Email::Filter::TakeAction - Change metadata of ticket via email
 
 =head1 DESCRIPTION
 
-This extension parse content of incomming messages for list commands. Format
-of commands is:
+This extension parses the body and headers of incoming messages for
+list commands. Format of commands is:
 
     Command: value
     Command: value
@@ -183,6 +183,10 @@ sub GetCurrentUser {
 
     $RT::Logger->debug("Running CommandByMail as ".$args{'CurrentUser'}->UserObj->Name);
 
+    my $headername = $new_config
+	    ? RT->Config->Get('CommandByMailHeader')
+	    : $RT::CommandByMailHeader;
+
     # find the content
     my @content;
     my @parts = $args{'Message'}->parts_DFS;
@@ -194,6 +198,10 @@ sub GetCurrentUser {
             @content = $body->as_lines;
             last;
         }
+    }
+
+    if (defined $headername) {
+	    unshift @content, $args{'Message'}->head->get_all($headername);
     }
 
     my @items;


### PR DESCRIPTION
This allows us to parse a configurable header for commands too, by
setting the CommandByMailHeader setting.
