### PR TITLE
Add support for only inspecting headers, not the body

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -57,5 +57,10 @@ CommandByMailHeader like:
 
     Set($CommandByMailHeader, "X-RT-Command");
 
+If you only want it to look in headers and not the body, you can set
+CommandByMailOnlyHeaders to a true value, like:
+
+    Set($CommandByMailOnlyHeaders, 1);
+
 Enjoy.
 

--- a/lib/RT/Interface/Email/Filter/TakeAction.pm
+++ b/lib/RT/Interface/Email/Filter/TakeAction.pm
@@ -200,17 +200,23 @@ sub GetCurrentUser {
 	    ? RT->Config->Get('CommandByMailHeader')
 	    : $RT::CommandByMailHeader;
 
-    # find the content
-    my @content;
-    my @parts = $args{'Message'}->parts_DFS;
-    foreach my $part (@parts) {
-        my $body = $part->bodyhandle or next;
+    my $only_headers = $new_config
+	    ? RT->Config->Get('CommandByMailOnlyHeaders')
+	    : $RT::CommandByMailOnlyHeaders;
 
-        #if it looks like it has pseudoheaders, that's our content
-        if ( $body->as_string =~ /^(?:\S+)(?:{.*})?:/m ) {
-            @content = $body->as_lines;
-            last;
-        }
+    # find the content
+    my @content = ();
+    if (not defined $only_headers or not $only_headers) {
+	    my @parts = $args{'Message'}->parts_DFS;
+	    foreach my $part (@parts) {
+		    my $body = $part->bodyhandle or next;
+
+		    #if it looks like it has pseudoheaders, that's our content
+		    if ( $body->as_string =~ /^(?:\S+)(?:{.*})?:/m ) {
+			    @content = $body->as_lines;
+			    last;
+		    }
+	    }
     }
 
     if (defined $headername) {


### PR DESCRIPTION
Default is to still look in body, but if you want the module to only
look in the defined header, use Set($CommandByMailOnlyHeaders, 1);
