### PR TITLE
Only check text attachments for commands

### DIFF
--- a/lib/RT/Extension/CommandByMail.pm
+++ b/lib/RT/Extension/CommandByMail.pm
@@ -353,7 +353,7 @@ sub ProcessCommands {
 
 	# Only check text attachments for commands
 	my $content_type = $part->head->get('content-type', 0);
-	next unless $head_type =~ 'text';
+	next unless $head_type =~ '^\s*text/';
 
         #if it looks like it has pseudoheaders, that's our content
         if ( $body->as_string =~ /^(?:\S+)(?:{.*})?:/m ) {

--- a/lib/RT/Extension/CommandByMail.pm
+++ b/lib/RT/Extension/CommandByMail.pm
@@ -351,6 +351,10 @@ sub ProcessCommands {
     foreach my $part (@parts) {
         my $body = $part->bodyhandle or next;
 
+	# Only check text attachments for commands
+	my $content_type = $part->head->get('content-type', 0);
+	next unless $head_type =~ 'text';
+
         #if it looks like it has pseudoheaders, that's our content
         if ( $body->as_string =~ /^(?:\S+)(?:{.*})?:/m ) {
             @content = $body->as_lines;

--- a/lib/RT/Extension/CommandByMail.pm
+++ b/lib/RT/Extension/CommandByMail.pm
@@ -353,7 +353,7 @@ sub ProcessCommands {
 
 	# Only check text attachments for commands
 	my $content_type = $part->head->get('content-type', 0);
-	next unless $head_type =~ '^\s*text/';
+	next unless $content_type =~ '^\s*text/';
 
         #if it looks like it has pseudoheaders, that's our content
         if ( $body->as_string =~ /^(?:\S+)(?:{.*})?:/m ) {


### PR DESCRIPTION
Today, CommandByMail checks each part of the body for possible commands. This means it will also scan parts that does not contain commands, such as a base64 encoded file. This again can lead to significant parsing time for a mail, possibly leading to error-messages for a mail, even though it (eventually) has been successfully delivered.

This change simply adds a small check, where it skips the part unless the content-type header starts with 'text/'.

I did not include the 'message' content-type, as forwarded messages are usually of this type - this can cause users to perform commands unintentionally when they forward a message.
I am somewhat unsure if multipart/, and application/ type messages should also be allowed - at least for application/, the same argument could be made as for why message is dropped.